### PR TITLE
Fix markdown syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Compiles down to a single folder of JS files in ES6.
 * `/spec/unit_tests` contains all tests that don't require a server to run
 * `/spec/integ_tests` contains all tests that run inside the mock server
 
-##Compilation
+## Compilation
 
 Run `npm run start` to start the gulp watcher for *.ts file changes.
 The watcher does not check TS compile errors or lint, so use your IDE to check those.


### PR DESCRIPTION
Markdown requires spacing between heading size and text content. This change fixes the README.